### PR TITLE
test: harmonize naming and fix structural bugs

### DIFF
--- a/test/calculators/__snapshots__/compound-interest.test.ts.snap
+++ b/test/calculators/__snapshots__/compound-interest.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`calculators/compound-interest > should return diagram data 1`] = `
+exports[`calculators/compound-interest > returns diagram data 1`] = `
 {
   "CAPITAL_LIST": [
     5100,
@@ -252,7 +252,7 @@ exports[`calculators/compound-interest > should return diagram data 1`] = `
 }
 `;
 
-exports[`calculators/compound-interest > should return finalCapital, totalPayments and totalInterest on monthly interest base 1`] = `
+exports[`calculators/compound-interest > returns finalCapital, totalPayments and totalInterest on monthly interest base 1`] = `
 {
   "finalCapital": "23.828€",
   "totalInterest": "6.828€",
@@ -260,7 +260,7 @@ exports[`calculators/compound-interest > should return finalCapital, totalPaymen
 }
 `;
 
-exports[`calculators/compound-interest > should return finalCapital, totalPayments and totalInterest on monthly interest base without start capital 1`] = `
+exports[`calculators/compound-interest > returns finalCapital, totalPayments and totalInterest on monthly interest base without start capital 1`] = `
 {
   "finalCapital": "15.593€",
   "totalInterest": "3.593€",
@@ -268,7 +268,7 @@ exports[`calculators/compound-interest > should return finalCapital, totalPaymen
 }
 `;
 
-exports[`calculators/compound-interest > should return finalCapital, totalPayments and totalInterest on quarterly interest base 1`] = `
+exports[`calculators/compound-interest > returns finalCapital, totalPayments and totalInterest on quarterly interest base 1`] = `
 {
   "finalCapital": "55.805€",
   "totalInterest": "16.805€",
@@ -276,7 +276,7 @@ exports[`calculators/compound-interest > should return finalCapital, totalPaymen
 }
 `;
 
-exports[`calculators/compound-interest > should return finalCapital, totalPayments and totalInterest on yearly interest base 1`] = `
+exports[`calculators/compound-interest > returns finalCapital, totalPayments and totalInterest on yearly interest base 1`] = `
 {
   "finalCapital": "55.438€",
   "totalInterest": "16.438€",

--- a/test/calculators/__snapshots__/disability-insurance.test.ts.snap
+++ b/test/calculators/__snapshots__/disability-insurance.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`/calculators/disability-insurance > should return correct levels 1`] = `
+exports[`/calculators/disability-insurance > returns correct levels 1`] = `
 {
   "level1": "1.031€",
   "level2": "1.362€",

--- a/test/calculators/__snapshots__/gross-to-net.test.ts.snap
+++ b/test/calculators/__snapshots__/gross-to-net.test.ts.snap
@@ -354,7 +354,7 @@ exports[`calculators/gross-to-net > private health insurance > without employer 
 }
 `;
 
-exports[`calculators/gross-to-net > reduced health insurance > should return specific result for user made input 1`] = `
+exports[`calculators/gross-to-net > reduced health insurance > returns correct result for reduced health insurance 1`] = `
 {
   "outputDisableResCareInsurance": false,
   "outputEmployerTotalInsurances": "485€",
@@ -413,7 +413,7 @@ exports[`calculators/gross-to-net > reduced health insurance > should return spe
 }
 `;
 
-exports[`calculators/gross-to-net > tax year 2019 > should return specific result for tax year 2019 1`] = `
+exports[`calculators/gross-to-net > tax year 2019 > returns specific result for tax year 2019 1`] = `
 {
   "outputDisableResCareInsurance": false,
   "outputEmployerTotalInsurances": "506,25€",
@@ -472,7 +472,7 @@ exports[`calculators/gross-to-net > tax year 2019 > should return specific resul
 }
 `;
 
-exports[`calculators/gross-to-net > tax year 2020 > should return specific result for tax year 2020 1`] = `
+exports[`calculators/gross-to-net > tax year 2020 > returns specific result for tax year 2020 1`] = `
 {
   "outputDisableResCareInsurance": false,
   "outputEmployerTotalInsurances": "506,25€",
@@ -531,7 +531,7 @@ exports[`calculators/gross-to-net > tax year 2020 > should return specific resul
 }
 `;
 
-exports[`calculators/gross-to-net > tax year 2021 > should return specific result for tax year 2021 1`] = `
+exports[`calculators/gross-to-net > tax year 2021 > returns specific result for tax year 2021 1`] = `
 {
   "outputDisableResCareInsurance": false,
   "outputEmployerTotalInsurances": "506,25€",
@@ -590,7 +590,7 @@ exports[`calculators/gross-to-net > tax year 2021 > should return specific resul
 }
 `;
 
-exports[`calculators/gross-to-net > tax year 2022 > should return specific result for tax year 2022 1`] = `
+exports[`calculators/gross-to-net > tax year 2022 > returns specific result for tax year 2022 1`] = `
 {
   "outputDisableResCareInsurance": false,
   "outputEmployerTotalInsurances": "506,25€",
@@ -649,7 +649,7 @@ exports[`calculators/gross-to-net > tax year 2022 > should return specific resul
 }
 `;
 
-exports[`calculators/gross-to-net > tax year 2023 > should return specific result for tax year 2023 1`] = `
+exports[`calculators/gross-to-net > tax year 2023 > returns specific result for tax year 2023 1`] = `
 {
   "outputDisableResCareInsurance": false,
   "outputEmployerTotalInsurances": "506,25€",
@@ -708,7 +708,7 @@ exports[`calculators/gross-to-net > tax year 2023 > should return specific resul
 }
 `;
 
-exports[`calculators/gross-to-net > tax year 2024 > should return specific result for tax year 2024 1`] = `
+exports[`calculators/gross-to-net > tax year 2024 > returns specific result for tax year 2024 1`] = `
 {
   "outputDisableResCareInsurance": false,
   "outputEmployerTotalInsurances": "506,25€",
@@ -764,6 +764,124 @@ exports[`calculators/gross-to-net > tax year 2024 > should return specific resul
   "outputTotalInsurancesYear": "6.255€",
   "outputTotalTaxes": "176,33€",
   "outputTotalTaxesYear": "2.115,96€",
+}
+`;
+
+exports[`calculators/gross-to-net > tax year 2025 > returns specific result for tax year 2025 1`] = `
+{
+  "outputDisableResCareInsurance": false,
+  "outputEmployerTotalInsurances": "506,25€",
+  "outputEmployerTotalInsurancesYear": "6.075€",
+  "outputResCareInsuranceMonth": "60€",
+  "outputResCareInsurancePercentage": "2,40%",
+  "outputResCareInsuranceYear": "720€",
+  "outputResChurchTaxMonth": "0€",
+  "outputResChurchTaxPercentage": " (8% der Lohnsteuer)",
+  "outputResChurchTaxYear": "0€",
+  "outputResEmployerCareInsuranceMonth": "45€",
+  "outputResEmployerCareInsurancePercentage": "1,80%",
+  "outputResEmployerCareInsuranceYear": "540€",
+  "outputResEmployerGrossWageMonth": "3.007,75€",
+  "outputResEmployerGrossWageYear": "36.093€",
+  "outputResEmployerHealthInsuranceMonth": "196,25€",
+  "outputResEmployerHealthInsurancePercentage": "7,85%",
+  "outputResEmployerHealthInsuranceYear": "2.355€",
+  "outputResEmployerLevyOneMonth": "0€",
+  "outputResEmployerLevyOneYear": "0€",
+  "outputResEmployerLevyThreeMonth": "1,50€",
+  "outputResEmployerLevyThreeYear": "18€",
+  "outputResEmployerLevyTotal": "1,50€",
+  "outputResEmployerLevyTotalYear": "18€",
+  "outputResEmployerLevyTwoMonth": "0€",
+  "outputResEmployerLevyTwoYear": "0€",
+  "outputResEmployerPensionInsuranceMonth": "232,50€",
+  "outputResEmployerPensionInsurancePercentage": "9,30%",
+  "outputResEmployerPensionInsuranceYear": "2.790€",
+  "outputResEmployerUnemploymentInsuranceMonth": "32,50€",
+  "outputResEmployerUnemploymentInsurancePercentage": "1,30%",
+  "outputResEmployerUnemploymentInsuranceYear": "390€",
+  "outputResGrossWageMonth": "2.500€",
+  "outputResGrossWageYear": "30.000€",
+  "outputResHealthInsuranceMonth": "196,25€",
+  "outputResHealthInsurancePercentage": "7,85%",
+  "outputResHealthInsuranceYear": "2.355€",
+  "outputResIncomeTaxMonth": "199,25€",
+  "outputResIncomeTaxYear": "2.391€",
+  "outputResNetWageMonth": "1.779,50€",
+  "outputResNetWageYear": "21.354€",
+  "outputResPensionInsuranceMonth": "232,50€",
+  "outputResPensionInsurancePercentage": "9,30%",
+  "outputResPensionInsuranceYear": "2.790€",
+  "outputResPrivateHealthInsuranceEmployerMonth": "0€",
+  "outputResPrivateHealthInsuranceEmployerYear": "0€",
+  "outputResSolidaritySurchargeMonth": "0€",
+  "outputResSolidaritySurchargeYear": "0€",
+  "outputResUnemploymentInsuranceMonth": "32,50€",
+  "outputResUnemploymentInsurancePercentage": "1,30%",
+  "outputResUnemploymentInsuranceYear": "390€",
+  "outputTotalInsurances": "521,25€",
+  "outputTotalInsurancesYear": "6.255€",
+  "outputTotalTaxes": "199,25€",
+  "outputTotalTaxesYear": "2.391€",
+}
+`;
+
+exports[`calculators/gross-to-net > tax year 2026 > returns specific result for tax year 2026 1`] = `
+{
+  "outputDisableResCareInsurance": false,
+  "outputEmployerTotalInsurances": "506,25€",
+  "outputEmployerTotalInsurancesYear": "6.075€",
+  "outputResCareInsuranceMonth": "60€",
+  "outputResCareInsurancePercentage": "2,40%",
+  "outputResCareInsuranceYear": "720€",
+  "outputResChurchTaxMonth": "0€",
+  "outputResChurchTaxPercentage": " (8% der Lohnsteuer)",
+  "outputResChurchTaxYear": "0€",
+  "outputResEmployerCareInsuranceMonth": "45€",
+  "outputResEmployerCareInsurancePercentage": "1,80%",
+  "outputResEmployerCareInsuranceYear": "540€",
+  "outputResEmployerGrossWageMonth": "3.007,75€",
+  "outputResEmployerGrossWageYear": "36.093€",
+  "outputResEmployerHealthInsuranceMonth": "196,25€",
+  "outputResEmployerHealthInsurancePercentage": "7,85%",
+  "outputResEmployerHealthInsuranceYear": "2.355€",
+  "outputResEmployerLevyOneMonth": "0€",
+  "outputResEmployerLevyOneYear": "0€",
+  "outputResEmployerLevyThreeMonth": "1,50€",
+  "outputResEmployerLevyThreeYear": "18€",
+  "outputResEmployerLevyTotal": "1,50€",
+  "outputResEmployerLevyTotalYear": "18€",
+  "outputResEmployerLevyTwoMonth": "0€",
+  "outputResEmployerLevyTwoYear": "0€",
+  "outputResEmployerPensionInsuranceMonth": "232,50€",
+  "outputResEmployerPensionInsurancePercentage": "9,30%",
+  "outputResEmployerPensionInsuranceYear": "2.790€",
+  "outputResEmployerUnemploymentInsuranceMonth": "32,50€",
+  "outputResEmployerUnemploymentInsurancePercentage": "1,30%",
+  "outputResEmployerUnemploymentInsuranceYear": "390€",
+  "outputResGrossWageMonth": "2.500€",
+  "outputResGrossWageYear": "30.000€",
+  "outputResHealthInsuranceMonth": "196,25€",
+  "outputResHealthInsurancePercentage": "7,85%",
+  "outputResHealthInsuranceYear": "2.355€",
+  "outputResIncomeTaxMonth": "193,08€",
+  "outputResIncomeTaxYear": "2.316,96€",
+  "outputResNetWageMonth": "1.785,67€",
+  "outputResNetWageYear": "21.428,04€",
+  "outputResPensionInsuranceMonth": "232,50€",
+  "outputResPensionInsurancePercentage": "9,30%",
+  "outputResPensionInsuranceYear": "2.790€",
+  "outputResPrivateHealthInsuranceEmployerMonth": "0€",
+  "outputResPrivateHealthInsuranceEmployerYear": "0€",
+  "outputResSolidaritySurchargeMonth": "0€",
+  "outputResSolidaritySurchargeYear": "0€",
+  "outputResUnemploymentInsuranceMonth": "32,50€",
+  "outputResUnemploymentInsurancePercentage": "1,30%",
+  "outputResUnemploymentInsuranceYear": "390€",
+  "outputTotalInsurances": "521,25€",
+  "outputTotalInsurancesYear": "6.255€",
+  "outputTotalTaxes": "193,08€",
+  "outputTotalTaxesYear": "2.316,96€",
 }
 `;
 
@@ -1475,7 +1593,7 @@ exports[`calculators/gross-to-net > with page defaults > taxClass 6 1`] = `
 }
 `;
 
-exports[`calculators/gross-to-net > without pension insurance > should return specific result for user made input 1`] = `
+exports[`calculators/gross-to-net > without pension insurance > returns correct result without pension insurance 1`] = `
 {
   "outputDisableResCareInsurance": false,
   "outputEmployerTotalInsurances": "351,10€",
@@ -1531,123 +1649,5 @@ exports[`calculators/gross-to-net > without pension insurance > should return sp
   "outputTotalInsurancesYear": "4.393,20€",
   "outputTotalTaxes": "266,25€",
   "outputTotalTaxesYear": "3.195€",
-}
-`;
-
-exports[`tax year 2025 > should return specific result for tax year 2025 1`] = `
-{
-  "outputDisableResCareInsurance": false,
-  "outputEmployerTotalInsurances": "506,25€",
-  "outputEmployerTotalInsurancesYear": "6.075€",
-  "outputResCareInsuranceMonth": "60€",
-  "outputResCareInsurancePercentage": "2,40%",
-  "outputResCareInsuranceYear": "720€",
-  "outputResChurchTaxMonth": "0€",
-  "outputResChurchTaxPercentage": " (8% der Lohnsteuer)",
-  "outputResChurchTaxYear": "0€",
-  "outputResEmployerCareInsuranceMonth": "45€",
-  "outputResEmployerCareInsurancePercentage": "1,80%",
-  "outputResEmployerCareInsuranceYear": "540€",
-  "outputResEmployerGrossWageMonth": "3.007,75€",
-  "outputResEmployerGrossWageYear": "36.093€",
-  "outputResEmployerHealthInsuranceMonth": "196,25€",
-  "outputResEmployerHealthInsurancePercentage": "7,85%",
-  "outputResEmployerHealthInsuranceYear": "2.355€",
-  "outputResEmployerLevyOneMonth": "0€",
-  "outputResEmployerLevyOneYear": "0€",
-  "outputResEmployerLevyThreeMonth": "1,50€",
-  "outputResEmployerLevyThreeYear": "18€",
-  "outputResEmployerLevyTotal": "1,50€",
-  "outputResEmployerLevyTotalYear": "18€",
-  "outputResEmployerLevyTwoMonth": "0€",
-  "outputResEmployerLevyTwoYear": "0€",
-  "outputResEmployerPensionInsuranceMonth": "232,50€",
-  "outputResEmployerPensionInsurancePercentage": "9,30%",
-  "outputResEmployerPensionInsuranceYear": "2.790€",
-  "outputResEmployerUnemploymentInsuranceMonth": "32,50€",
-  "outputResEmployerUnemploymentInsurancePercentage": "1,30%",
-  "outputResEmployerUnemploymentInsuranceYear": "390€",
-  "outputResGrossWageMonth": "2.500€",
-  "outputResGrossWageYear": "30.000€",
-  "outputResHealthInsuranceMonth": "196,25€",
-  "outputResHealthInsurancePercentage": "7,85%",
-  "outputResHealthInsuranceYear": "2.355€",
-  "outputResIncomeTaxMonth": "199,25€",
-  "outputResIncomeTaxYear": "2.391€",
-  "outputResNetWageMonth": "1.779,50€",
-  "outputResNetWageYear": "21.354€",
-  "outputResPensionInsuranceMonth": "232,50€",
-  "outputResPensionInsurancePercentage": "9,30%",
-  "outputResPensionInsuranceYear": "2.790€",
-  "outputResPrivateHealthInsuranceEmployerMonth": "0€",
-  "outputResPrivateHealthInsuranceEmployerYear": "0€",
-  "outputResSolidaritySurchargeMonth": "0€",
-  "outputResSolidaritySurchargeYear": "0€",
-  "outputResUnemploymentInsuranceMonth": "32,50€",
-  "outputResUnemploymentInsurancePercentage": "1,30%",
-  "outputResUnemploymentInsuranceYear": "390€",
-  "outputTotalInsurances": "521,25€",
-  "outputTotalInsurancesYear": "6.255€",
-  "outputTotalTaxes": "199,25€",
-  "outputTotalTaxesYear": "2.391€",
-}
-`;
-
-exports[`tax year 2026 > should return specific result for tax year 2026 1`] = `
-{
-  "outputDisableResCareInsurance": false,
-  "outputEmployerTotalInsurances": "506,25€",
-  "outputEmployerTotalInsurancesYear": "6.075€",
-  "outputResCareInsuranceMonth": "60€",
-  "outputResCareInsurancePercentage": "2,40%",
-  "outputResCareInsuranceYear": "720€",
-  "outputResChurchTaxMonth": "0€",
-  "outputResChurchTaxPercentage": " (8% der Lohnsteuer)",
-  "outputResChurchTaxYear": "0€",
-  "outputResEmployerCareInsuranceMonth": "45€",
-  "outputResEmployerCareInsurancePercentage": "1,80%",
-  "outputResEmployerCareInsuranceYear": "540€",
-  "outputResEmployerGrossWageMonth": "3.007,75€",
-  "outputResEmployerGrossWageYear": "36.093€",
-  "outputResEmployerHealthInsuranceMonth": "196,25€",
-  "outputResEmployerHealthInsurancePercentage": "7,85%",
-  "outputResEmployerHealthInsuranceYear": "2.355€",
-  "outputResEmployerLevyOneMonth": "0€",
-  "outputResEmployerLevyOneYear": "0€",
-  "outputResEmployerLevyThreeMonth": "1,50€",
-  "outputResEmployerLevyThreeYear": "18€",
-  "outputResEmployerLevyTotal": "1,50€",
-  "outputResEmployerLevyTotalYear": "18€",
-  "outputResEmployerLevyTwoMonth": "0€",
-  "outputResEmployerLevyTwoYear": "0€",
-  "outputResEmployerPensionInsuranceMonth": "232,50€",
-  "outputResEmployerPensionInsurancePercentage": "9,30%",
-  "outputResEmployerPensionInsuranceYear": "2.790€",
-  "outputResEmployerUnemploymentInsuranceMonth": "32,50€",
-  "outputResEmployerUnemploymentInsurancePercentage": "1,30%",
-  "outputResEmployerUnemploymentInsuranceYear": "390€",
-  "outputResGrossWageMonth": "2.500€",
-  "outputResGrossWageYear": "30.000€",
-  "outputResHealthInsuranceMonth": "196,25€",
-  "outputResHealthInsurancePercentage": "7,85%",
-  "outputResHealthInsuranceYear": "2.355€",
-  "outputResIncomeTaxMonth": "193,08€",
-  "outputResIncomeTaxYear": "2.316,96€",
-  "outputResNetWageMonth": "1.785,67€",
-  "outputResNetWageYear": "21.428,04€",
-  "outputResPensionInsuranceMonth": "232,50€",
-  "outputResPensionInsurancePercentage": "9,30%",
-  "outputResPensionInsuranceYear": "2.790€",
-  "outputResPrivateHealthInsuranceEmployerMonth": "0€",
-  "outputResPrivateHealthInsuranceEmployerYear": "0€",
-  "outputResSolidaritySurchargeMonth": "0€",
-  "outputResSolidaritySurchargeYear": "0€",
-  "outputResUnemploymentInsuranceMonth": "32,50€",
-  "outputResUnemploymentInsurancePercentage": "1,30%",
-  "outputResUnemploymentInsuranceYear": "390€",
-  "outputTotalInsurances": "521,25€",
-  "outputTotalInsurancesYear": "6.255€",
-  "outputTotalTaxes": "193,08€",
-  "outputTotalTaxesYear": "2.316,96€",
 }
 `;

--- a/test/calculators/__snapshots__/net-policy.test.ts.snap
+++ b/test/calculators/__snapshots__/net-policy.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`calculators/net-policy > should have correct table data 1`] = `
+exports[`calculators/net-policy > has correct table data 1`] = `
 {
   "gain": {
     "etf": "203.774",

--- a/test/calculators/__snapshots__/savings.test.ts.snap
+++ b/test/calculators/__snapshots__/savings.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`/calculators/savings > endValue > should return right results for monthly monthly 1`] = `
+exports[`/calculators/savings > endValue > returns right results for monthly monthly 1`] = `
 {
   "deposits": "23.000€",
   "diagramData": {
@@ -262,7 +262,7 @@ exports[`/calculators/savings > endValue > should return right results for month
 }
 `;
 
-exports[`/calculators/savings > endValue > should return right results for monthly monthly without start capital 1`] = `
+exports[`/calculators/savings > endValue > returns right results for monthly monthly without start capital 1`] = `
 {
   "deposits": "12.000€",
   "diagramData": {
@@ -524,7 +524,7 @@ exports[`/calculators/savings > endValue > should return right results for month
 }
 `;
 
-exports[`/calculators/savings > endValue > should return right results for monthly yearly 1`] = `
+exports[`/calculators/savings > endValue > returns right results for monthly yearly 1`] = `
 {
   "deposits": "23.000€",
   "diagramData": {
@@ -786,7 +786,7 @@ exports[`/calculators/savings > endValue > should return right results for month
 }
 `;
 
-exports[`/calculators/savings > endValue > should return right results for yearly yearly 1`] = `
+exports[`/calculators/savings > endValue > returns right results for yearly yearly 1`] = `
 {
   "deposits": "23.000€",
   "diagramData": {
@@ -1048,7 +1048,7 @@ exports[`/calculators/savings > endValue > should return right results for yearl
 }
 `;
 
-exports[`/calculators/savings > monthlyDuration > should return right results for monthly monthly 1`] = `
+exports[`/calculators/savings > monthlyDuration > returns right results for monthly monthly 1`] = `
 {
   "deposits": "17.447,99€",
   "diagramData": {
@@ -1234,7 +1234,7 @@ exports[`/calculators/savings > monthlyDuration > should return right results fo
 }
 `;
 
-exports[`/calculators/savings > monthlyDuration > should return right results for monthly yearly 1`] = `
+exports[`/calculators/savings > monthlyDuration > returns right results for monthly yearly 1`] = `
 {
   "deposits": "17.864,67€",
   "diagramData": {
@@ -1426,7 +1426,7 @@ exports[`/calculators/savings > monthlyDuration > should return right results fo
 }
 `;
 
-exports[`/calculators/savings > monthlyDuration > should return right results for yearly yearly 1`] = `
+exports[`/calculators/savings > monthlyDuration > returns right results for yearly yearly 1`] = `
 {
   "deposits": "17.743,32€",
   "diagramData": {
@@ -1616,7 +1616,7 @@ exports[`/calculators/savings > monthlyDuration > should return right results fo
 }
 `;
 
-exports[`/calculators/savings > savingRate > should return right results for accumulating 1`] = `
+exports[`/calculators/savings > savingRate > returns right results for accumulating 1`] = `
 {
   "deposits": "9.364,50€",
   "diagramData": {
@@ -1806,7 +1806,7 @@ exports[`/calculators/savings > savingRate > should return right results for acc
 }
 `;
 
-exports[`/calculators/savings > savingRate > should return right results for monthly monthly 1`] = `
+exports[`/calculators/savings > savingRate > returns right results for monthly monthly 1`] = `
 {
   "deposits": "9.358,76€",
   "diagramData": {
@@ -1996,7 +1996,7 @@ exports[`/calculators/savings > savingRate > should return right results for mon
 }
 `;
 
-exports[`/calculators/savings > savingRate > should return right results for monthly yearly 1`] = `
+exports[`/calculators/savings > savingRate > returns right results for monthly yearly 1`] = `
 {
   "deposits": "9.393,20€",
   "diagramData": {
@@ -2186,7 +2186,7 @@ exports[`/calculators/savings > savingRate > should return right results for mon
 }
 `;
 
-exports[`/calculators/savings > savingRate > should return right results for yearly yearly 1`] = `
+exports[`/calculators/savings > savingRate > returns right results for yearly yearly 1`] = `
 {
   "deposits": "9.191,60€",
   "diagramData": {
@@ -2376,7 +2376,7 @@ exports[`/calculators/savings > savingRate > should return right results for yea
 }
 `;
 
-exports[`/calculators/savings > startValue > should return right results for monthly monthly 1`] = `
+exports[`/calculators/savings > startValue > returns right results for monthly monthly 1`] = `
 {
   "deposits": "17.862,46€",
   "diagramData": {
@@ -2566,7 +2566,7 @@ exports[`/calculators/savings > startValue > should return right results for mon
 }
 `;
 
-exports[`/calculators/savings > startValue > should return right results for monthly yearly 1`] = `
+exports[`/calculators/savings > startValue > returns right results for monthly yearly 1`] = `
 {
   "deposits": "18.068,87€",
   "diagramData": {
@@ -2756,7 +2756,7 @@ exports[`/calculators/savings > startValue > should return right results for mon
 }
 `;
 
-exports[`/calculators/savings > startValue > should return right results for yearly yearly 1`] = `
+exports[`/calculators/savings > startValue > returns right results for yearly yearly 1`] = `
 {
   "deposits": "17.310,89€",
   "diagramData": {
@@ -2946,7 +2946,7 @@ exports[`/calculators/savings > startValue > should return right results for yea
 }
 `;
 
-exports[`/calculators/savings > yearlyInterest > should return right results for monthly monthly 1`] = `
+exports[`/calculators/savings > yearlyInterest > returns right results for monthly monthly 1`] = `
 {
   "deposits": "23.000€",
   "diagramData": {
@@ -3208,7 +3208,7 @@ exports[`/calculators/savings > yearlyInterest > should return right results for
 }
 `;
 
-exports[`/calculators/savings > yearlyInterest > should return right results for monthly yearly 1`] = `
+exports[`/calculators/savings > yearlyInterest > returns right results for monthly yearly 1`] = `
 {
   "deposits": "23.000€",
   "diagramData": {
@@ -3470,7 +3470,7 @@ exports[`/calculators/savings > yearlyInterest > should return right results for
 }
 `;
 
-exports[`/calculators/savings > yearlyInterest > should return right results for yearly yearly 1`] = `
+exports[`/calculators/savings > yearlyInterest > returns right results for yearly yearly 1`] = `
 {
   "deposits": "23.000€",
   "diagramData": {

--- a/test/calculators/compound-interest.test.ts
+++ b/test/calculators/compound-interest.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { compoundInterest } from '../../src/calculators/compound-interest'
 
 describe('calculators/compound-interest', () => {
-  it('should return finalCapital, totalPayments and totalInterest on monthly interest base', () => {
+  it('returns finalCapital, totalPayments and totalInterest on monthly interest base', () => {
     const result = compoundInterest.validateAndCalculate({
       startCapital: 5000,
       monthlyPayment: 100,
@@ -15,7 +15,7 @@ describe('calculators/compound-interest', () => {
     expect({ finalCapital, totalPayments, totalInterest }).toMatchSnapshot()
   })
 
-  it('should return finalCapital, totalPayments and totalInterest on monthly interest base without start capital', () => {
+  it('returns finalCapital, totalPayments and totalInterest on monthly interest base without start capital', () => {
     const result = compoundInterest.validateAndCalculate({
       startCapital: 0,
       monthlyPayment: 100,
@@ -28,7 +28,7 @@ describe('calculators/compound-interest', () => {
     expect({ finalCapital, totalPayments, totalInterest }).toMatchSnapshot()
   })
 
-  it('should return finalCapital, totalPayments and totalInterest on quarterly interest base', () => {
+  it('returns finalCapital, totalPayments and totalInterest on quarterly interest base', () => {
     const result = compoundInterest.validateAndCalculate({
       startCapital: 15000,
       monthlyPayment: 200,
@@ -41,7 +41,7 @@ describe('calculators/compound-interest', () => {
     expect({ finalCapital, totalPayments, totalInterest }).toMatchSnapshot()
   })
 
-  it('should return finalCapital, totalPayments and totalInterest on yearly interest base', () => {
+  it('returns finalCapital, totalPayments and totalInterest on yearly interest base', () => {
     const result = compoundInterest.validateAndCalculate({
       startCapital: 15000,
       monthlyPayment: 200,
@@ -54,7 +54,7 @@ describe('calculators/compound-interest', () => {
     expect({ finalCapital, totalPayments, totalInterest }).toMatchSnapshot()
   })
 
-  it('should return diagram data', () => {
+  it('returns diagram data', () => {
     const result = compoundInterest.validateAndCalculate({
       startCapital: 5000,
       monthlyPayment: 100,

--- a/test/calculators/disability-insurance.test.ts
+++ b/test/calculators/disability-insurance.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { disabilityInsurance } from '../../src/calculators/disability-insurance'
 
 describe('/calculators/disability-insurance', () => {
-  it('should return correct levels', async () => {
+  it('returns correct levels', async () => {
     const result = disabilityInsurance.validateAndCalculate({
       grossIncome: 4000,
       netIncome: 2602,
@@ -11,7 +11,7 @@ describe('/calculators/disability-insurance', () => {
     expect(result.tableData).toMatchSnapshot()
   })
 
-  it('should include custom pension amount if useCustomPensionAmount is true', () => {
+  it('includes custom pension amount if useCustomPensionAmount is true', () => {
     const result = disabilityInsurance.validateAndCalculate({
       grossIncome: 4000,
       netIncome: 2602,
@@ -22,7 +22,7 @@ describe('/calculators/disability-insurance', () => {
     expect(result.tableData.levelCustom).toBe('500,00€')
   })
 
-  it('should calculate half disability pension correctly', () => {
+  it('calculates half disability pension correctly', () => {
     const resultWithCustom = disabilityInsurance.validateAndCalculate({
       grossIncome: 4000,
       netIncome: 2602,
@@ -40,7 +40,7 @@ describe('/calculators/disability-insurance', () => {
     )
   })
 
-  it('should parse query-style flag values correctly', () => {
+  it('parses query-style flag values correctly', () => {
     const result = disabilityInsurance.validateAndCalculate({
       grossIncome: 4000,
       netIncome: 2602,

--- a/test/calculators/gross-to-net.test.ts
+++ b/test/calculators/gross-to-net.test.ts
@@ -241,7 +241,7 @@ describe('calculators/gross-to-net', () => {
   })
 
   describe('reduced health insurance', () => {
-    it('should return specific result for user made input', () => {
+    it('returns correct result for reduced health insurance', () => {
       const result = grossToNet.validateAndCalculate(
         fakeTestValues({
           healthInsurance: REDUCED_HEALTH_INSURANCE,
@@ -254,7 +254,7 @@ describe('calculators/gross-to-net', () => {
   })
 
   describe('without pension insurance', () => {
-    it('should return specific result for user made input', () => {
+    it('returns correct result without pension insurance', () => {
       const result = grossToNet.validateAndCalculate(
         fakeTestValues({
           pensionInsurance: NO_PENSION_INSURANCE,
@@ -311,7 +311,7 @@ describe('calculators/gross-to-net', () => {
   })
 
   describe('tax year 2019', () => {
-    it('should return specific result for tax year 2019', () => {
+    it('returns specific result for tax year 2019', () => {
       const result = grossToNet.validateAndCalculate(
         fakeTestValues({
           accountingYear: '2019',
@@ -323,7 +323,7 @@ describe('calculators/gross-to-net', () => {
   })
 
   describe('tax year 2020', () => {
-    it('should return specific result for tax year 2020', () => {
+    it('returns specific result for tax year 2020', () => {
       const result = grossToNet.validateAndCalculate(
         fakeTestValues({
           accountingYear: '2020',
@@ -335,7 +335,7 @@ describe('calculators/gross-to-net', () => {
   })
 
   describe('tax year 2021', () => {
-    it('should return specific result for tax year 2021', () => {
+    it('returns specific result for tax year 2021', () => {
       const result = grossToNet.validateAndCalculate(
         fakeTestValues({
           accountingYear: '2021',
@@ -347,7 +347,7 @@ describe('calculators/gross-to-net', () => {
   })
 
   describe('tax year 2022', () => {
-    it('should return specific result for tax year 2022', () => {
+    it('returns specific result for tax year 2022', () => {
       const result = grossToNet.validateAndCalculate(fakeTestValues())
 
       expect(result).toMatchSnapshot()
@@ -355,7 +355,7 @@ describe('calculators/gross-to-net', () => {
   })
 
   describe('tax year 2023', () => {
-    it('should return specific result for tax year 2023', () => {
+    it('returns specific result for tax year 2023', () => {
       const result = grossToNet.validateAndCalculate(
         fakeTestValues({
           accountingYear: '2023',
@@ -367,7 +367,7 @@ describe('calculators/gross-to-net', () => {
   })
 
   describe('tax year 2024', () => {
-    it('should return specific result for tax year 2024', () => {
+    it('returns specific result for tax year 2024', () => {
       const result = grossToNet.validateAndCalculate(
         fakeTestValues({
           accountingYear: '2024',
@@ -377,46 +377,48 @@ describe('calculators/gross-to-net', () => {
       expect(result).toMatchSnapshot()
     })
   })
-})
 
-describe('tax year 2025', () => {
-  it('should return specific result for tax year 2025', () => {
-    const result = grossToNet.validateAndCalculate(
-      fakeTestValues({
-        accountingYear: '2025',
-      }),
-    )
+  describe('tax year 2025', () => {
+    it('returns specific result for tax year 2025', () => {
+      const result = grossToNet.validateAndCalculate(
+        fakeTestValues({
+          accountingYear: '2025',
+        }),
+      )
 
-    expect(result).toMatchSnapshot()
-  })
-})
-
-describe('tax year 2026', () => {
-  it('should return specific result for tax year 2026', () => {
-    const result = grossToNet.validateAndCalculate(
-      fakeTestValues({
-        accountingYear: '2026',
-      }),
-    )
-
-    expect(result).toMatchSnapshot()
+      expect(result).toMatchSnapshot()
+    })
   })
 
-  it('should account for new care insurance contribution', () => {
-    const result = grossToNet.validateAndCalculate(
-      fakeTestValues({
-        accountingYear: '2026',
-        grossWage: 8900,
-        children: 2,
-        childTaxAllowance: 0,
-        taxClass: 3,
-        state: STATE_BERLIN,
-        churchTax: 1,
-        additionalContribution: 2.9,
-      }),
-    )
-    expect(result.outputResIncomeTaxMonth).toMatchInlineSnapshot(`"1.448,33€"`)
-    expect(result.outputResChurchTaxMonth).toMatchInlineSnapshot(`"130,35€"`)
+  describe('tax year 2026', () => {
+    it('returns specific result for tax year 2026', () => {
+      const result = grossToNet.validateAndCalculate(
+        fakeTestValues({
+          accountingYear: '2026',
+        }),
+      )
+
+      expect(result).toMatchSnapshot()
+    })
+
+    it('accounts for new care insurance contribution', () => {
+      const result = grossToNet.validateAndCalculate(
+        fakeTestValues({
+          accountingYear: '2026',
+          grossWage: 8900,
+          children: 2,
+          childTaxAllowance: 0,
+          taxClass: 3,
+          state: STATE_BERLIN,
+          churchTax: 1,
+          additionalContribution: 2.9,
+        }),
+      )
+      expect(result.outputResIncomeTaxMonth).toMatchInlineSnapshot(
+        `"1.448,33€"`,
+      )
+      expect(result.outputResChurchTaxMonth).toMatchInlineSnapshot(`"130,35€"`)
+    })
   })
 })
 

--- a/test/calculators/gross-to-net.test.ts
+++ b/test/calculators/gross-to-net.test.ts
@@ -401,7 +401,7 @@ describe('calculators/gross-to-net', () => {
       expect(result).toMatchSnapshot()
     })
 
-    it('accounts for new care insurance contribution', () => {
+    it('returns expected income tax and church tax for multiple children under 2026 care insurance rules', () => {
       const result = grossToNet.validateAndCalculate(
         fakeTestValues({
           accountingYear: '2026',

--- a/test/calculators/net-policy.test.ts
+++ b/test/calculators/net-policy.test.ts
@@ -21,7 +21,7 @@ const SHARED_INPUT = {
 }
 
 describe('calculators/net-policy', () => {
-  it('should have correct table data', () => {
+  it('has correct table data', () => {
     const data = netPolicy.validateAndCalculate({
       ...SHARED_INPUT,
       duration: 35,
@@ -30,7 +30,7 @@ describe('calculators/net-policy', () => {
     expect(data.tableData).toMatchSnapshot()
   })
 
-  it('should work with fixed costs', () => {
+  it('works with fixed costs', () => {
     const data = netPolicy.validateAndCalculate({
       ...SHARED_INPUT,
       duration: 35,
@@ -41,7 +41,7 @@ describe('calculators/net-policy', () => {
     expect(data.tableData.netWorth.policy).toMatchInlineSnapshot(`"335.482"`)
   })
 
-  it('should use different calculation for durations under 12 years', () => {
+  it('uses different calculation for durations under 12 years', () => {
     const data = netPolicy.validateAndCalculate({
       ...SHARED_INPUT,
       duration: 10,

--- a/test/calculators/savings.test.ts
+++ b/test/calculators/savings.test.ts
@@ -3,7 +3,7 @@ import { savings } from '../../src/calculators/savings'
 
 describe('/calculators/savings', () => {
   describe('endValue', () => {
-    it('should return right results for yearly yearly', async () => {
+    it('returns right results for yearly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'endValue',
         startValue: '5000',
@@ -20,7 +20,7 @@ describe('/calculators/savings', () => {
 
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly monthly', async () => {
+    it('returns right results for monthly monthly', async () => {
       const data = savings.validateAndCalculate({
         output: 'endValue',
         startValue: '5000',
@@ -36,7 +36,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly yearly', async () => {
+    it('returns right results for monthly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'endValue',
         startValue: '5000',
@@ -52,7 +52,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly monthly without start capital', async () => {
+    it('returns right results for monthly monthly without start capital', async () => {
       const data = savings.validateAndCalculate({
         output: 'endValue',
         startValue: '0',
@@ -71,7 +71,7 @@ describe('/calculators/savings', () => {
   })
 
   describe('startValue', () => {
-    it('should return right results for yearly yearly', async () => {
+    it('returns right results for yearly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'startValue',
         endValue: '20000',
@@ -87,7 +87,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly monthly', async () => {
+    it('returns right results for monthly monthly', async () => {
       const data = savings.validateAndCalculate({
         output: 'startValue',
         endValue: '20000',
@@ -103,7 +103,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly yearly', async () => {
+    it('returns right results for monthly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'startValue',
         endValue: '20000',
@@ -122,7 +122,7 @@ describe('/calculators/savings', () => {
   })
 
   describe('yearlyInterest', () => {
-    it('should return right results for yearly yearly', async () => {
+    it('returns right results for yearly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'yearlyInterest',
         endValue: '30000',
@@ -138,7 +138,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly monthly', async () => {
+    it('returns right results for monthly monthly', async () => {
       const data = savings.validateAndCalculate({
         output: 'yearlyInterest',
         endValue: '30000',
@@ -154,7 +154,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly yearly', async () => {
+    it('returns right results for monthly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'yearlyInterest',
         endValue: '30000',
@@ -173,7 +173,7 @@ describe('/calculators/savings', () => {
   })
 
   describe('monthlyDuration', () => {
-    it('should return right results for yearly yearly', async () => {
+    it('returns right results for yearly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'monthlyDuration',
         yearlyInterest: '3',
@@ -189,7 +189,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly monthly', async () => {
+    it('returns right results for monthly monthly', async () => {
       const data = savings.validateAndCalculate({
         output: 'monthlyDuration',
         yearlyInterest: '3',
@@ -205,7 +205,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly yearly', async () => {
+    it('returns right results for monthly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'monthlyDuration',
         yearlyInterest: '3',
@@ -224,7 +224,7 @@ describe('/calculators/savings', () => {
   })
 
   describe('savingRate', () => {
-    it('should return right results for yearly yearly', async () => {
+    it('returns right results for yearly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'savingRate',
         startValue: '5000',
@@ -240,7 +240,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly monthly', async () => {
+    it('returns right results for monthly monthly', async () => {
       const data = savings.validateAndCalculate({
         output: 'savingRate',
         startValue: '5000',
@@ -256,7 +256,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for monthly yearly', async () => {
+    it('returns right results for monthly yearly', async () => {
       const data = savings.validateAndCalculate({
         output: 'savingRate',
         startValue: '5000',
@@ -272,7 +272,7 @@ describe('/calculators/savings', () => {
       })
       expect(data).toMatchSnapshot()
     })
-    it('should return right results for accumulating', async () => {
+    it('returns right results for accumulating', async () => {
       const data = savings.validateAndCalculate({
         output: 'savingRate',
         startValue: '5000',

--- a/test/utils/financial.test.ts
+++ b/test/utils/financial.test.ts
@@ -4,12 +4,12 @@ import { fv, nper, pmt, pv, rate, xirr } from '../../src/utils/financial'
 
 describe('financial functions', () => {
   describe('pmt', () => {
-    it('should return excel rmz/pmt', () => {
+    it('returns excel rmz/pmt', () => {
       const expectedResult = 602.95
       const calculation = pmt(0.03, 180, -20000, 0)
       expect(formatResult(calculation)).toBe(formatResult(expectedResult))
     })
-    it('should return excel rmz/pmt type 1', () => {
+    it('returns excel rmz/pmt type 1', () => {
       const expectedResult = 585.39
       const calculation = pmt(0.03, 180, -20000, 0, 1)
       expect(formatResult(calculation)).toBe(formatResult(expectedResult))
@@ -17,12 +17,12 @@ describe('financial functions', () => {
   })
 
   describe('pv', () => {
-    it('should return excel pv/bw', () => {
+    it('returns excel pv/bw', () => {
       const expectedResult = -3463.73
       const calculation = pv(0.03, 180, 100, 30000)
       expect(formatResult(calculation)).toBe(formatResult(expectedResult))
     })
-    it('should return excel pv/bw type 1', () => {
+    it('returns excel pv/bw type 1', () => {
       const expectedResult = -3563.24
       const calculation = pv(0.03, 180, 100, 30000, 1)
       expect(formatResult(calculation)).toBe(formatResult(expectedResult))
@@ -30,12 +30,12 @@ describe('financial functions', () => {
   })
 
   describe('fv', () => {
-    it('should return excel fv/zw', () => {
+    it('returns excel fv/zw', () => {
       const expectedResult = 21506.45
       const calculation = fv(0.03 / 12, 180, -150, 8000)
       expect(formatResult(calculation)).toBe(formatResult(expectedResult))
     })
-    it('should return excel fv/zw type 1', () => {
+    it('returns excel fv/zw type 1', () => {
       const expectedResult = 21591.56
       const calculation = fv(0.03 / 12, 180, -150, 8000, 1)
       expect(formatResult(calculation)).toBe(formatResult(expectedResult))
@@ -43,12 +43,12 @@ describe('financial functions', () => {
   })
 
   describe('nper', () => {
-    it('should return excel nper/zzr', () => {
+    it('returns excel nper/zzr', () => {
       const expectedResult = 179.8
       const calculation = nper(3 / 12 / 100, -150, 0, 34000)
       expect(formatResult(calculation)).toBe(formatResult(expectedResult))
     })
-    it('should return excel nper/zzr type 1', () => {
+    it('returns excel nper/zzr type 1', () => {
       const expectedResult = 179.44
       const calculation = nper(3 / 12 / 100, -150, 0, 34000, 1)
       expect(formatResult(calculation)).toBe(formatResult(expectedResult))
@@ -56,17 +56,17 @@ describe('financial functions', () => {
   })
 
   describe('rate', () => {
-    it('should return excel rate/zins', () => {
+    it('returns excel rate/zins', () => {
       const expectedResult = 14.167
       const calculation = rate(15, 1800, 0, -80000) * 100
       expect(formatPercent(calculation)).toBe(formatPercent(expectedResult))
     })
-    it('should return excel rate/zins type 1', () => {
+    it('returns excel rate/zins type 1', () => {
       const expectedResult = 12.697
       const calculation = rate(15, 1800, 0, -80000, 1) * 100
       expect(formatPercent(calculation)).toBe(formatPercent(expectedResult))
     })
-    it('should return excel rate/zins with 0 payment', () => {
+    it('returns excel rate/zins with 0 payment', () => {
       const expectedResult = 58.489
       const calculation = rate(15, 0, -1000, 1000000, 1) * 100
       expect(formatPercent(calculation)).toBe(formatPercent(expectedResult))
@@ -74,7 +74,7 @@ describe('financial functions', () => {
   })
 
   describe('xirr', () => {
-    it('should return correct excel xirr/xintzinsfuss', () => {
+    it('returns correct excel xirr/xintzinsfuss', () => {
       const values = [-10000, 2750, 4250, 3250, 2750]
       const dates = [
         new Date('2008-01-01'),

--- a/test/utils/formatters.test.ts
+++ b/test/utils/formatters.test.ts
@@ -17,83 +17,83 @@ describe('formatting methods', () => {
     })
 
     describe('pad', () => {
-      it('should pad numbers < 10', () => {
+      it('pads numbers < 10', () => {
         expect(pad(1)).toBe('01')
       })
-      it('should not pad numbers >= 10', () => {
+      it('does not pad numbers >= 10', () => {
         expect(pad(10)).toBe('10')
       })
     })
 
     describe('formatInput', () => {
-      it('should remove dots and spaces', () => {
+      it('removes dots and spaces', () => {
         expect(formatInput('123 4567.890')).toBe(1234567890)
       })
-      it('should remove multiple dots', () => {
+      it('removes multiple dots', () => {
         expect(formatInput('1.234.567.890')).toBe(1234567890)
       })
-      it('should remove multiple spaces', () => {
+      it('removes multiple spaces', () => {
         expect(formatInput('1 234 567 890')).toBe(1234567890)
       })
-      it('should replace commata with dot', () => {
+      it('replaces commata with dot', () => {
         expect(formatInput('123,456')).toBe(123.456)
       })
-      it('should be inverse of formatNumber()', () => {
+      it('is inverse of formatNumber()', () => {
         const input = '1.234,56'
         expect(formatNumber(formatInput(input), 2)).toBe(input)
       })
     })
 
     describe('formatResult', () => {
-      it('should return decimal value if under 1000', () => {
+      it('returns decimal value if under 1000', () => {
         expect(formatResult(512.25)).toBe('512,25€')
       })
-      it('should append decimal value if under 1000', () => {
+      it('appends decimal value if under 1000', () => {
         expect(formatResult(1)).toBe('1,00€')
       })
-      it('should return no decimal value if above 1000', () => {
+      it('returns no decimal value if above 1000', () => {
         expect(formatResult(1234)).toBe('1.234€')
       })
-      it('should return no decimal value if equal 1000', () => {
+      it('returns no decimal value if equal 1000', () => {
         expect(formatResult(1000)).toBe('1.000€')
       })
-      it('should format negative numbers', () => {
+      it('formats negative numbers', () => {
         expect(formatResult(-9.99)).toBe('-9,99€')
       })
-      it('should round up', () => {
+      it('rounds up', () => {
         expect(formatResult(1234.56)).toBe('1.235€')
       })
-      it('should return pow format for large numbers', () => {
+      it('returns pow format for large numbers', () => {
         expect(formatResult(1 * 10 ** 21)).toBe('1×10²¹€')
       })
-      it('should return pow format with decimal for large numbers', () => {
+      it('returns pow format with decimal for large numbers', () => {
         expect(formatResult(1.2 * 10 ** 21)).toBe('1,2×10²¹€')
       })
-      it('should return pow format with cropped decimal for large numbers', () => {
+      it('returns pow format with cropped decimal for large numbers', () => {
         expect(formatResult(1.299999e21)).toBe('1,2×10²¹€')
       })
-      it('should handle Dinero objects', () => {
+      it('handles Dinero objects', () => {
         const dineroObj = dinero({ amount: 12345, currency: EUR })
         expect(formatResult(dineroObj)).toBe('123,45€')
       })
     })
 
     describe('formatResultWithTwoOptionalDecimals', () => {
-      it('should show decimals when number has fractional part', () => {
+      it('shows decimals when number has fractional part', () => {
         expect(formatResultWithTwoOptionalDecimals(99.5)).toBe('99,50€')
       })
-      it('should not show decimals for whole numbers', () => {
+      it('does not show decimals for whole numbers', () => {
         expect(formatResultWithTwoOptionalDecimals(99)).toBe('99€')
       })
-      it('should support custom suffix', () => {
+      it('supports custom suffix', () => {
         expect(formatResultWithTwoOptionalDecimals(99, ' EUR')).toBe('99 EUR')
       })
-      it('should handle exponential numbers', () => {
+      it('handles exponential numbers', () => {
         expect(formatResultWithTwoOptionalDecimals(1.2 * 10 ** 21)).toBe(
           '1,2×10²¹€',
         )
       })
-      it('should handle Dinero objects', () => {
+      it('handles Dinero objects', () => {
         const dineroObj = dinero({ amount: 9900, currency: EUR })
         expect(formatResultWithTwoOptionalDecimals(dineroObj)).toBe('99€')
 
@@ -105,34 +105,31 @@ describe('formatting methods', () => {
     })
 
     describe('formatPercent', () => {
-      it('should round up', () => {
+      it('rounds up', () => {
         expect(formatPercent(12.4437)).toBe('12,444%')
-      })
-      it('should round down', () => {
-        expect(formatNumber(12.01)).toBe('12')
-      })
-      it('should round trunc', () => {
-        expect(formatNumber(1.555, 2)).toBe('1,55')
-      })
-      it('should set correct decimal points and naming', () => {
-        expect(formatNumber(13.547, 2)).toBe('13,55')
-      })
-      it('should return pow format for large numbers', () => {
-        expect(formatNumber(1e40)).toBe('1×10⁴⁰')
-      })
-      it('should throw error for negative precision', () => {
-        expect(() => formatNumber(1, -2)).toThrowError()
       })
     })
 
     describe('formatNumber', () => {
-      it('should return % value and round', () => {
+      it('rounds to whole number', () => {
         expect(formatNumber(12.66)).toBe('13')
       })
-      it('should set correct decimal points and naming', () => {
+      it('rounds down', () => {
+        expect(formatNumber(12.01)).toBe('12')
+      })
+      it('rounds trunc', () => {
+        expect(formatNumber(1.555, 2)).toBe('1,55')
+      })
+      it('sets correct decimal points and naming', () => {
         expect(formatNumber(13.547, 2)).toBe('13,55')
       })
-      it('should throw error for non-finite values', () => {
+      it('returns pow format for large numbers', () => {
+        expect(formatNumber(1e40)).toBe('1×10⁴⁰')
+      })
+      it('throws error for negative precision', () => {
+        expect(() => formatNumber(1, -2)).toThrowError()
+      })
+      it('throws error for non-finite values', () => {
         expect(() => formatNumber(Number.NaN)).toThrowError(
           'NaN is not a valid number',
         )
@@ -152,13 +149,13 @@ describe('formatting methods', () => {
     })
 
     describe('formatResult', () => {
-      it('should return decimal value if under 1000', () => {
+      it('returns decimal value if under 1000', () => {
         expect(formatResult(512.25)).toBe('512,25€')
       })
-      it('should return no decimal value above 1000', () => {
+      it('returns no decimal value above 1000', () => {
         expect(formatResult(1234.46)).toBe('1 234€')
       })
-      it('should round up', () => {
+      it('rounds up', () => {
         expect(formatResult(1234.56)).toBe('1 235€')
       })
     })

--- a/test/utils/i18n.test.ts
+++ b/test/utils/i18n.test.ts
@@ -13,15 +13,15 @@ describe('i18n', () => {
     setLocale('de')
   })
 
-  it('should have a fallback locale', () => {
+  it('has a fallback locale', () => {
     expect(fallbackLocale).toBe('de')
   })
 
-  it('should have a current locale', () => {
+  it('has a current locale', () => {
     expect(getLocale()).toBe('de')
   })
 
-  it('should have a list of locales', () => {
+  it('has a list of locales', () => {
     expect(locales).toMatchInlineSnapshot(`
       [
         "de",
@@ -30,18 +30,18 @@ describe('i18n', () => {
     `)
   })
 
-  it('should have a function to check if a locale is valid', () => {
+  it('has a function to check if a locale is valid', () => {
     expect(isValidLocale('de')).toBe(true)
     expect(isValidLocale('fr')).toBe(true)
     expect(isValidLocale('en')).toBe(false)
   })
 
-  it('should have a function to set the locale', () => {
+  it('has a function to set the locale', () => {
     setLocale('fr')
     expect(getLocale()).toBe('fr')
   })
 
-  it('should have a function to set the locale if it is valid', () => {
+  it('has a function to set the locale if it is valid', () => {
     setMaybeLocale('fr')
     expect(getLocale()).toBe('fr')
     setMaybeLocale('ko')

--- a/test/utils/savings-utils.test.ts
+++ b/test/utils/savings-utils.test.ts
@@ -396,7 +396,7 @@ describe('/calculators/savings-utils', () => {
           interestIntervalType,
           expectedValue,
         ] of expected) {
-          it(`should return correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
+          it(`returns correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
             const result = savingsEndValue.validateAndCalculate({
               ...input,
               saveIntervalType,
@@ -428,7 +428,7 @@ describe('/calculators/savings-utils', () => {
             input._savingRatePerYear,
           )
 
-          it(`should return correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
+          it(`returns correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
             const result = savingsPayment.validateAndCalculate({
               ...input,
               saveIntervalType,
@@ -464,7 +464,7 @@ describe('/calculators/savings-utils', () => {
             input._savingRatePerYear,
           )
 
-          it(`should return correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
+          it(`returns correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
             const result = savingsStartValue.validateAndCalculate({
               ...input,
               saveIntervalType,
@@ -502,7 +502,7 @@ describe('/calculators/savings-utils', () => {
             input._savingRatePerYear,
           )
 
-          it(`should return correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
+          it(`returns correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
             const result = savingsDuration.validateAndCalculate({
               ...input,
               saveIntervalType,
@@ -535,7 +535,7 @@ describe('/calculators/savings-utils', () => {
             input._savingRatePerYear,
           )
 
-          it(`should return correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
+          it(`returns correct values for ${saveIntervalType} / ${interestIntervalType}`, () => {
             const result =
               100 *
               savingsInterestRate.validateAndCalculate({
@@ -577,7 +577,7 @@ describe('/calculators/savings-utils', () => {
       useCompoundInterest: false,
     } as const
 
-    it('should delay interest calculation until first full year with yearly/yearly intervals', () => {
+    it('delays interest calculation until first full year with yearly/yearly intervals', () => {
       const result = calcDiagramData({
         ...baseConfig,
         saveIntervalType: 'yearly',
@@ -589,7 +589,7 @@ describe('/calculators/savings-utils', () => {
       expect(interests[12]).toBeGreaterThan(0)
     })
 
-    it('should delay interest calculation until first quarter with yearly/quarterly intervals', () => {
+    it('delays interest calculation until first quarter with yearly/quarterly intervals', () => {
       const result = calcDiagramData({
         ...baseConfig,
         saveIntervalType: 'yearly',
@@ -601,7 +601,7 @@ describe('/calculators/savings-utils', () => {
       expect(interests[3]).toBeGreaterThan(0)
     })
 
-    it('should delay interest calculation until first quarter with monthly/quarterly intervals', () => {
+    it('delays interest calculation until first quarter with monthly/quarterly intervals', () => {
       const result = calcDiagramData({
         ...baseConfig,
         saveIntervalType: 'monthly',
@@ -613,7 +613,7 @@ describe('/calculators/savings-utils', () => {
       expect(interests[3]).toBeGreaterThan(0)
     })
 
-    it('should calculate interest immediately with yearly/monthly intervals', () => {
+    it('calculates interest immediately with yearly/monthly intervals', () => {
       const result = calcDiagramData({
         ...baseConfig,
         saveIntervalType: 'yearly',
@@ -624,7 +624,7 @@ describe('/calculators/savings-utils', () => {
       expect(interests[0]).toBeGreaterThan(0)
     })
 
-    it('should return empty interest list when duration is zero', () => {
+    it('returns empty interest list when duration is zero', () => {
       const result = calcDiagramData({
         ...baseConfig,
         yearlyDuration: 0,

--- a/test/utils/validator.test.ts
+++ b/test/utils/validator.test.ts
@@ -19,26 +19,26 @@ import {
 } from '../../src/utils/validation'
 
 describe('roundToTwoDecimals', () => {
-  it('should round to two decimal places', () => {
+  it('rounds to two decimal places', () => {
     expect(roundToTwoDecimals(1.234)).toBe(1.23)
     expect(roundToTwoDecimals(1.235)).toBe(1.24)
     expect(roundToTwoDecimals(1.999)).toBe(2)
     expect(roundToTwoDecimals(0.1 + 0.2)).toBe(0.3)
   })
 
-  it('should handle whole numbers', () => {
+  it('handles whole numbers', () => {
     expect(roundToTwoDecimals(5)).toBe(5)
     expect(roundToTwoDecimals(0)).toBe(0)
   })
 
-  it('should handle negative values', () => {
+  it('handles negative values', () => {
     expect(roundToTwoDecimals(-1.234)).toBe(-1.23)
     expect(roundToTwoDecimals(-1.235)).toBe(-1.24)
   })
 })
 
 describe('toMonthly', () => {
-  it('should convert yearly to monthly', () => {
+  it('converts yearly to monthly', () => {
     expect(toMonthly(12)).toBe(1)
     expect(toMonthly(120)).toBe(10)
     expect(toMonthly(0)).toBe(0)
@@ -46,7 +46,7 @@ describe('toMonthly', () => {
 })
 
 describe('toPercentRate', () => {
-  it('should convert percent to rate', () => {
+  it('converts percent to rate', () => {
     expect(toPercentRate(50)).toBe(0.5)
     expect(toPercentRate(0)).toBe(0)
     expect(toPercentRate(-50)).toBe(-0.5)
@@ -54,7 +54,7 @@ describe('toPercentRate', () => {
 })
 
 describe('toMonthlyConformalRate', () => {
-  it('should convert yearly percent to monthly conformal rate', () => {
+  it('converts yearly percent to monthly conformal rate', () => {
     expect(toMonthlyConformalRate(0)).toBe(0)
     expect(toMonthlyConformalRate(12.68)).toBeCloseTo(0.01, 5)
     expect(toMonthlyConformalRate(213.84)).toBeCloseTo(0.1, 5)
@@ -62,7 +62,7 @@ describe('toMonthlyConformalRate', () => {
 })
 
 describe('toDinero', () => {
-  it('should convert euros to Dinero object', () => {
+  it('converts euros to Dinero object', () => {
     const dineroValue = toDinero(10)
     expect(dineroValue).not.toBeInstanceOf(Number)
     expect(toDecimal(dineroValue)).toEqual('10.00')
@@ -70,7 +70,7 @@ describe('toDinero', () => {
     expect(toSnapshot(dineroValue).currency.code).toBe('EUR')
   })
 
-  it('should handle zero and negative values', () => {
+  it('handles zero and negative values', () => {
     const zeroValue = toDinero(0)
     expect(toDecimal(zeroValue)).toEqual('0.00')
 
@@ -78,34 +78,34 @@ describe('toDinero', () => {
     expect(toDecimal(negativeValue)).toEqual('-5.00')
   })
 
-  it('should handle fractional euros', () => {
+  it('handles fractional euros', () => {
     const fractionalValue = toDinero(10.42)
     expect(toDecimal(fractionalValue)).toEqual('10.42')
   })
 
-  it('should round to nearest cent', () => {
+  it('rounds to nearest cent', () => {
     const dineroValue = toDinero(10.005)
     expect(toDecimal(dineroValue)).toEqual('10.01')
   })
 })
 
 describe('toDineroMultiplier', () => {
-  it('should convert rate to Dinero multiplier', () => {
+  it('converts rate to Dinero multiplier', () => {
     const multiplier = toDineroMultiplier(1)
     expect(multiplier).toEqual({ amount: 1_000_000, scale: 6 }) // 1 * 10^6 = 1_000_000
   })
 
-  it('should handle zero and negative rates', () => {
+  it('handles zero and negative rates', () => {
     const zeroMultiplier = toDineroMultiplier(0)
     expect(zeroMultiplier).toEqual({ amount: 0, scale: 6 })
   })
 
-  it('should handle fractional rates', () => {
+  it('handles fractional rates', () => {
     const fractionalMultiplier = toDineroMultiplier(0.05)
     expect(fractionalMultiplier).toEqual({ amount: 50_000, scale: 6 })
   })
 
-  it('should round to nearest millionth', () => {
+  it('rounds to nearest millionth', () => {
     const smallMultiplier = toDineroMultiplier(0.0000005)
     expect(smallMultiplier).toEqual({ amount: 1, scale: 6 })
 
@@ -113,7 +113,7 @@ describe('toDineroMultiplier', () => {
     expect(tinyMultiplier).toEqual({ amount: 0, scale: 6 })
   })
 
-  it('should work with Dinero calculations', () => {
+  it('works with Dinero calculations', () => {
     const multiplier = toDineroMultiplier(0.1) // 10% -> 0.1
     const baseAmount = toDinero(100) // 100 euros
     const expectedResult = toDinero(10) // 10 euros (10% of 100)
@@ -131,19 +131,19 @@ describe('dineroToNumber', () => {
   function eur(cents: number) {
     return dinero({ amount: cents, currency: EUR })
   }
-  it('should convert whole-euro amounts', () => {
+  it('converts whole-euro amounts', () => {
     expect(dineroToNumber(eur(10000))).toBe(100)
   })
 
-  it('should convert amounts with cents', () => {
+  it('converts amounts with cents', () => {
     expect(dineroToNumber(eur(10050))).toBe(100.5)
   })
 
-  it('should convert zero', () => {
+  it('converts zero', () => {
     expect(dineroToNumber(eur(0))).toBe(0)
   })
 
-  it('should convert negative amounts', () => {
+  it('converts negative amounts', () => {
     expect(dineroToNumber(eur(-500))).toBe(-5)
   })
 })


### PR DESCRIPTION
## Summary

Grooming pass on the test suite – mostly naming harmonisation, with a few real structural bugs caught along the way.

- **Naming** – dropped the `should` prefix across all 10 test files and switched to assertive voice (`returns …`, `rounds …`, `throws …`).
- **Orphaned describes** – `tax year 2025` and `tax year 2026` in `gross-to-net.test.ts` were sitting at module scope instead of nested under the parent `calculators/gross-to-net`. Moved them inside and prefixed the matching snapshot keys.
- **Copy-paste bug in `formatters.test.ts`** – the `formatPercent` describe block contained five tests that actually called `formatNumber`. 
- **Duplicate test names** – two `should return specific result for user made input` tests in `gross-to-net.test.ts`.

## Why

Spotted the same shape of inconsistencies while running a grooming pass on `ff-workers`. Keeping naming style consistent across the Finanzfluss test suites, and the structural fixes catch a couple of things the existing naming was actively hiding (snapshots with wrong parent prefixes, tests living in the wrong block).

No production code touched.

## Test plan

- [x] `pnpm test --run` – 733/733 passing on first try, no iteration